### PR TITLE
Fix conditional for triggering sort on change events

### DIFF
--- a/ampersand-filtered-subcollection.js
+++ b/ampersand-filtered-subcollection.js
@@ -348,8 +348,10 @@ assign(FilteredCollection.prototype, Events, {
         if (action !== 'ignore') this.trigger.apply(this, arguments);
 
         //If we were asked to sort, or we aren't gonna get a sort later and had a sortable property change
-        if (action === 'sort' || (propName && !sortable && includes([this.comparator, this.collection.comparator]), propName))
-       {
+        if (
+            action === 'sort' ||
+            (propName && !sortable && includes([this.comparator, this.collection.comparator], propName))
+        ) {
             if (ordered && model.isNew) return; //We'll get a sort later
             this.models = this._sortModels(this.models);
             if (this.comparator && action !== 'sort') {


### PR DESCRIPTION
The original conditional included the predicate:

```js
    (propName && !sortable && includes([this.comparator, this.collection.comparator]), propName)
```

However, that last `propName` is *not* part of the `includes()` call like it was intended to be.

Thanks to the magic of commas, that makes the entire predicate `true`, and so we run a sort on any change event.