### PR TITLE
Don't bubble change events that are not from models in subcollection

### DIFF
--- a/ampersand-filtered-subcollection.js
+++ b/ampersand-filtered-subcollection.js
@@ -11,7 +11,6 @@ var reduce = require('lodash.reduce');
 var sortBy = require('lodash.sortby');
 var sortedIndex = require('lodash.sortedindex');
 var union = require('lodash.union');
-var startsWith = require('lodash.startswith');
 var classExtend = require('ampersand-class-extend');
 var Events = require('ampersand-events');
 
@@ -296,12 +295,13 @@ assign(FilteredCollection.prototype, Events, {
         }
     },
 
-    _onCollectionEvent: function (eventName, model, that, options) {
+    _onCollectionEvent: function (event, model, that, options) {
         /*jshint -W030 */
         options || (options = {});
         var accepted;
-        var propName = eventName.split(':')[1];
-        var action = eventName;
+        var eventName = event.split(':')[0];
+        var propName = event.split(':')[1];
+        var action = event;
         var alreadyHave = this._indexedGet(model);
         //Whether or not we are to expect a sort event from our collection later
         var sortable = this.collection.comparator && (options.at == null) && (options.sort !== false);
@@ -326,11 +326,9 @@ assign(FilteredCollection.prototype, Events, {
             if (!this._testModel(model) || alreadyHave) {
                 action = 'ignore';
             }
-        } else if (startsWith(action, 'change')) {
+        } else if (eventName === 'change' && !this._contains(model)) {
             //Don't trigger change events that are not from this collection
-            if (!this._contains(model)) {
-                action = 'ignore';
-            }
+            action = 'ignore';
         }
 
         // action has now passed the filters
@@ -341,7 +339,7 @@ assign(FilteredCollection.prototype, Events, {
             if (this.models.length === 0) {
                 this._runFilters();
             } else {
-                this._addModel(model, options, eventName);
+                this._addModel(model, options, event);
                 this.trigger('add', model, this);
             }
             return;

--- a/ampersand-filtered-subcollection.js
+++ b/ampersand-filtered-subcollection.js
@@ -11,6 +11,7 @@ var reduce = require('lodash.reduce');
 var sortBy = require('lodash.sortby');
 var sortedIndex = require('lodash.sortedindex');
 var union = require('lodash.union');
+var startsWith = require('lodash.startswith');
 var classExtend = require('ampersand-class-extend');
 var Events = require('ampersand-events');
 
@@ -107,6 +108,9 @@ assign(FilteredCollection.prototype, Events, {
         return index[query] || index[query[this.mainIndex]] || this._indexes.cid[query] || this._indexes.cid[query.cid];
     },
 
+    _contains: function (model) {
+        return this.models.indexOf(model) !== -1;
+    },
 
     _parseSpec: function (spec) {
         if (spec.watched) this._watch(spec.watched);
@@ -322,6 +326,11 @@ assign(FilteredCollection.prototype, Events, {
             if (!this._testModel(model) || alreadyHave) {
                 action = 'ignore';
             }
+        } else if (startsWith(action, 'change')) {
+            //Don't trigger change events that are not from this collection
+            if (!this._contains(model)) {
+                action = 'ignore';
+            }
         }
 
         // action has now passed the filters
@@ -345,7 +354,9 @@ assign(FilteredCollection.prototype, Events, {
            return;
         }
 
-        if (action !== 'ignore') this.trigger.apply(this, arguments);
+        if (action !== 'ignore') {
+          this.trigger.apply(this, arguments);
+        }
 
         //If we were asked to sort, or we aren't gonna get a sort later and had a sortable property change
         if (

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lodash.reduce": "^3.1.0",
     "lodash.sortby": "^3.1.0",
     "lodash.sortedindex": "^3.1.0",
+    "lodash.startswith": "^3.0.1",
     "lodash.union": "^3.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "lodash.reduce": "^3.1.0",
     "lodash.sortby": "^3.1.0",
     "lodash.sortedindex": "^3.1.0",
-    "lodash.startswith": "^3.0.1",
     "lodash.union": "^3.1.0"
   },
   "devDependencies": {

--- a/test/main.js
+++ b/test/main.js
@@ -603,3 +603,59 @@ test('Serialize/toJSON method', function (t) {
     t.equal(JSON.stringify([{id: 'thing'}, {id: 'other'}]), JSON.stringify(sub));
     t.end();
 });
+
+test('doesn\'t bubble \'change\' events that are not from the filtered collection', function (t) {
+    var M = Model.extend({
+      props: {
+        prop: 'number'
+      }
+    });
+    var c = new Collection([
+      new M({prop: 0}),
+      new M({prop: 10})
+    ]);
+    var sub = new SubCollection(c, {
+      where: {
+        prop: 0
+      }
+    });
+    sub.on('change', function () {
+      t.fail('sub bubbled change event of model not in sub');
+    });
+    c.on('change', function () {
+      t.pass('collection triggered change event');
+    });
+    c.models[1].prop = 11;
+    t.end();
+});
+
+test('doesn\'t bubble \'change:derivedProperty\' events that are not from the filtered collection', function (t) {
+    var M = Model.extend({
+      props: {
+        prop: 'number'
+      },
+      derived: {
+        derivedProperty: {
+          deps: ['prop'],
+          fn: function () { return 123; }
+        }
+      }
+    });
+    var c = new Collection([
+      new M({prop: 0}),
+      new M({prop: 10})
+    ]);
+    var sub = new SubCollection(c, {
+      where: {
+        prop: 0
+      }
+    });
+    sub.on('change:derivedProperty', function () {
+      t.fail('sub bubbled change:derviedProperty event of model not in sub');
+    });
+    c.on('change:derivedProperty', function () {
+      t.pass('collection triggered change:derivedProperty event');
+    });
+    c.models[1].prop = 11;
+    t.end();
+});


### PR DESCRIPTION
Currently subcollection triggers all change and change:xx events, even if the model is not in the subcollection.

This fixes #16 and #15