### PR TITLE
Run filters after collection has been synced

### DIFF
--- a/ampersand-filtered-subcollection.js
+++ b/ampersand-filtered-subcollection.js
@@ -329,7 +329,9 @@ assign(FilteredCollection.prototype, Events, {
 
         // action has now passed the filters
 
-        if (action === 'reset') return this._runFilters();
+        if (action === 'reset' || action === 'sync') {
+            return this._runFilters();
+        }
 
         if (action === 'add') {
             if (this.models.length === 0) {


### PR DESCRIPTION
Right now when fetching more collection data from server the subcollection doesn't update itself, this fixes it.

I don't think there is any good way to test this without mocking the fetch function of ampersand-rest-collection. If there is such a module let me know and I will create a test for it.