### PR TITLE
Bubble comparator change events

### DIFF
--- a/ampersand-filtered-subcollection.js
+++ b/ampersand-filtered-subcollection.js
@@ -320,8 +320,6 @@ assign(FilteredCollection.prototype, Events, {
                 action = 'add';
             } else if (alreadyHave && !accepted) {
                 action = 'remove';
-            } else {
-                action = 'ignore';
             }
         } else if (action === 'add') { //See if we really want to add
             if (!this._testModel(model) || alreadyHave) {

--- a/test/main.js
+++ b/test/main.js
@@ -717,3 +717,20 @@ test('sort by 2 argument function', function (t) {
     t.deepEqual(pluck(sub2.models, 'prop'), [3, 2, 1]);
     t.end();
 });
+
+test('listens to comparator property change event', function (t) {
+    var M = Model.extend({ props: { prop: 'number' } });
+    var c = new Collection([
+        new M({prop: 3}),
+        new M({prop: 1}),
+        new M({prop: 2})
+    ]);
+    var sub = new SubCollection(c, {
+        comparator: 'prop'
+    });
+    sub.on('change:prop', function () {
+        t.pass('Change triggered');
+        t.end();
+    });
+    sub.models[0].prop = 10;
+});


### PR DESCRIPTION
Fixes #22

This pull request changes it so that the change events of watched and comparator properties get bubbled. Let me know if there is an edge case where the subcollection should not bubble watched properties' change events.