### PR TITLE
Sort models with the collection as context

### DIFF
--- a/ampersand-filtered-subcollection.js
+++ b/ampersand-filtered-subcollection.js
@@ -164,7 +164,7 @@ assign(FilteredCollection.prototype, Events, {
                 newModels = sortBy(newModels, comparator);
             } else {
                 // lodash sortBy does not allow for traditional a, b comparisons
-                newModels = newModels.sort(comparator);
+                newModels = newModels.sort.call(this.collection, comparator);
             }
         } else {
             // This only happens when parent got a .set with options.at defined


### PR DESCRIPTION
Hi, I ran into an issue where my filtered sub collection wasn't sorting properly. I was seeing this error message:

```
Uncaught TypeError: Cannot read property 'indexOf' of undefined
```

The `comparator` function in my original collection references a property on the collection and needs to be called with the collection as context for it to work.

![screen shot 2016-04-29 at 3 04 57 pm](https://cloud.githubusercontent.com/assets/1173886/14928263/6b5be30c-0e1c-11e6-9835-1451e9b9e18b.png)

I'm not too familiar with the ins and outs of `ampersand-filtered-subcollection`. Would this cause any other issues?
