### PR TITLE
Bump lodash to v4, and bump other deps

### DIFF
--- a/ampersand-filtered-subcollection.js
+++ b/ampersand-filtered-subcollection.js
@@ -1,16 +1,17 @@
 /*$AMPERSAND_VERSION*/
-var includes = require('lodash.includes');
-var difference = require('lodash.difference');
-var forEach = require('lodash.foreach');
-var every = require('lodash.every');
-var assign = require('lodash.assign');
-var isArray = require('lodash.isarray');
-var isEqual = require('lodash.isequal');
-var keys = require('lodash.keys');
-var reduce = require('lodash.reduce');
-var sortBy = require('lodash.sortby');
-var sortedIndex = require('lodash.sortedindex');
-var union = require('lodash.union');
+var includes = require('lodash/includes');
+var difference = require('lodash/difference');
+var bind = require('lodash/bind');
+var forEach = require('lodash/forEach');
+var every = require('lodash/every');
+var assign = require('lodash/assign');
+var isArray = require('lodash/isArray');
+var isEqual = require('lodash/isEqual');
+var keys = require('lodash/keys');
+var reduce = require('lodash/reduce');
+var sortBy = require('lodash/sortBy');
+var sortedIndexBy = require('lodash/sortedIndexBy');
+var union = require('lodash/union');
 var classExtend = require('ampersand-class-extend');
 var Events = require('ampersand-events');
 
@@ -112,11 +113,11 @@ assign(FilteredCollection.prototype, Events, {
         //this.comparator = this.collection.comparator;
         if (spec.comparator) this.comparator = spec.comparator;
         if (spec.where) {
-            forEach(spec.where, function (value, item) {
+            forEach(spec.where, bind(function (value, item) {
                 this._addFilter(function (model) {
                     return (model.get ? model.get(item) : model[item]) === value;
                 });
-            }, this);
+            }, this));
             // also make sure we watch all `where` keys
             this._watch(keys(spec.where));
         }
@@ -180,7 +181,7 @@ assign(FilteredCollection.prototype, Events, {
         //Whether or not we are to expect a sort event from our collection later
         var sortable = eventName === 'add' && this.collection.comparator && (options.at == null) && options.sort !== false;
         if (!sortable) {
-            var index = sortedIndex(newModels, model, comparator);
+            var index = sortedIndexBy(newModels, model, comparator);
             newModels.splice(index, 0, model);
         } else {
             newModels.push(model);
@@ -282,13 +283,13 @@ assign(FilteredCollection.prototype, Events, {
         // save 'em
         this.models = newModels;
 
-        forEach(toRemove, function (model) {
+        forEach(toRemove, bind(function (model) {
             this.trigger('remove', model, this);
-        }, this);
+        }, this));
 
-        forEach(toAdd, function (model) {
+        forEach(toAdd, bind(function (model) {
             this.trigger('add', model, this);
-        }, this);
+        }, this));
 
         // unless we have the same models in same order trigger `sort`
         if (!isEqual(existingModels, newModels) && this.comparator) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "start": "zuul --local -- test/main.js",
     "test": "zuul --phantom -- test/main.js",
-    "test-ci": "zuul -- test/main.js"
+    "test-ci": "zuul -- test/main.js",
+    "lint": "jshint .",
+    "validate": "npm ls"
   },
   "repository": {
     "type": "git",
@@ -30,29 +32,20 @@
   "dependencies": {
     "ampersand-class-extend": "^1.0.1",
     "ampersand-events": "^1.0.1",
-    "lodash.assign": "^3.0.0",
-    "lodash.difference": "^3.1.0",
-    "lodash.every": "^3.2.0",
-    "lodash.foreach": "^3.0.2",
-    "lodash.includes": "^3.1.0",
-    "lodash.isarray": "^3.0.1",
-    "lodash.isequal": "^3.0.1",
-    "lodash.keys": "^3.0.5",
-    "lodash.reduce": "^3.1.0",
-    "lodash.sortby": "^3.1.0",
-    "lodash.sortedindex": "^3.1.0",
-    "lodash.union": "^3.1.0"
+    "lodash": "^4.11.2"
   },
   "devDependencies": {
     "ampersand-collection": "^1.4.0",
-    "ampersand-state": "^4.4.4",
+    "ampersand-state": "^5.0.1",
     "jshint": "^2.6.0",
-    "lodash.find": "^3.2.0",
-    "lodash.pluck": "^3.0.2",
-    "lodash.toarray": "^3.0.0",
-    "phantomjs": "^1.9.19",
-    "precommit-hook": "^1.0.7",
+    "phantomjs": "^2.1.7",
+    "precommit-hook": "^3.0.0",
     "tape": "^4.4.0",
     "zuul": "^3.9.0"
-  }
+  },
+  "pre-commit": [
+    "lint",
+    "validate",
+    "test"
+  ]
 }

--- a/test/main.js
+++ b/test/main.js
@@ -2,11 +2,11 @@ var test = require('tape');
 var Collection = require('ampersand-collection');
 var SubCollection = require('../ampersand-filtered-subcollection');
 var Model = require('ampersand-state');
-var every = require('lodash.every');
-var find = require('lodash.find');
-var keys = require('lodash.keys');
-var pluck = require('lodash.pluck');
-var toArray = require('lodash.toarray');
+var every = require('lodash/every');
+var find = require('lodash/find');
+var keys = require('lodash/keys');
+var map = require('lodash/map');
+var toArray = require('lodash/toArray');
 
 // our widget model
 var Widget = Model.extend({
@@ -516,7 +516,7 @@ test('reset', function (t) {
     t.equal(sub.comparator, base.comparator, 'comparator should be reset');
     t.equal(sortTriggered, 0, 'should not have triggered a `sort`');
 
-    t.deepEqual(pluck(sub.models, 'id'), pluck(base.models, 'id'), 'base and sub should have same models');
+    t.deepEqual(map(sub.models, 'id'), map(base.models, 'id'), 'base and sub should have same models');
 
     t.ok(every(itemsAdded, function (item) {
         return item.sweet !== true || item.awesomeness !== 6;
@@ -674,7 +674,7 @@ test('sort by string', function (t) {
     var sub = new SubCollection(c, {
         comparator: 'prop'
     });
-    t.deepEqual(pluck(sub.models, 'prop'), [1, 2, 3]);
+    t.deepEqual(map(sub.models, 'prop'), [1, 2, 3]);
     t.end();
 });
 
@@ -688,7 +688,7 @@ test('sort by string when property changes', function (t) {
         comparator: 'prop'
     });
     m1.prop = 4;
-    t.deepEqual(pluck(sub.models, 'prop'), [2, 3, 4]);
+    t.deepEqual(map(sub.models, 'prop'), [2, 3, 4]);
     t.end();
 });
 
@@ -708,8 +708,8 @@ test('sort by 1 argument function', function (t) {
             return model.prop;
         },
     });
-    t.deepEqual(pluck(sub1.models, 'prop'), [3, 2, 1]);
-    t.deepEqual(pluck(sub2.models, 'prop'), [1, 2, 3]);
+    t.deepEqual(map(sub1.models, 'prop'), [3, 2, 1]);
+    t.deepEqual(map(sub2.models, 'prop'), [1, 2, 3]);
     t.end();
 });
 
@@ -725,9 +725,9 @@ test('sort by 1 argument function when property changes', function (t) {
         },
         watched: ['prop'],
     });
-    t.deepEqual(pluck(sub.models, 'prop'), [1, 2, 3]);
+    t.deepEqual(map(sub.models, 'prop'), [1, 2, 3]);
     m1.prop = 4;
-    t.deepEqual(pluck(sub.models, 'prop'), [2, 3, 4]);
+    t.deepEqual(map(sub.models, 'prop'), [2, 3, 4]);
     t.end();
 });
 
@@ -747,8 +747,8 @@ test('sort by 2 argument function', function (t) {
             return b.prop - a.prop;
         },
     });
-    t.deepEqual(pluck(sub1.models, 'prop'), [1, 2, 3]);
-    t.deepEqual(pluck(sub2.models, 'prop'), [3, 2, 1]);
+    t.deepEqual(map(sub1.models, 'prop'), [1, 2, 3]);
+    t.deepEqual(map(sub2.models, 'prop'), [3, 2, 1]);
     t.end();
 });
 
@@ -764,9 +764,9 @@ test('sort by 2 argument function when property changes', function (t) {
         },
         watched: ['prop'],
     });
-    t.deepEqual(pluck(sub.models, 'prop'), [1, 2, 3]);
+    t.deepEqual(map(sub.models, 'prop'), [1, 2, 3]);
     m1.prop = 4;
-    t.deepEqual(pluck(sub.models, 'prop'), [2, 3, 4]);
+    t.deepEqual(map(sub.models, 'prop'), [2, 3, 4]);
     t.end();
 });
 


### PR DESCRIPTION
A few lodash v4 specific notes:

- forEach no longer takes a context, so you have to bind the function separately.
- pluck replaced by map, which is the only change in the tests.
- sortedIndex was renamed to sortedIndexBy

I'd recommend merging this first: https://github.com/AmpersandJS/ampersand-class-extend/pull/9