### PR TITLE
Should run collection methods on collection

### DIFF
--- a/ampersand-filtered-subcollection.js
+++ b/ampersand-filtered-subcollection.js
@@ -412,7 +412,7 @@ var collectionMethods = [
 
 collectionMethods.forEach(function (method) {
     FilteredCollection.prototype[method] = function () {
-        return this.collection[method].apply(this, arguments);
+        return this.collection[method].apply(this.collection, arguments);
     };
 });
 


### PR DESCRIPTION
If not, and you have a subcollection as the collection, then you get infinite recursion and a bad time.

This fixes a serious issue that appears when you filter a paginated subcollection or vise-versa.